### PR TITLE
Build for ppc64

### DIFF
--- a/.dockerfile-security.rego
+++ b/.dockerfile-security.rego
@@ -86,7 +86,7 @@ deny[msg] {
 
 exception[rules] {
   input[i].Cmd == "from"
-  input[i].Value[0] == "maven"
+  input[i].Value[0] == "maven:3.6.3-openjdk-11"
 
   rules := ["untrusted_base_image"]
 }

--- a/.dockerfile-security.rego
+++ b/.dockerfile-security.rego
@@ -86,7 +86,7 @@ deny[msg] {
 
 exception[rules] {
   input[i].Cmd == "from"
-  input[i].Value[0] == "maven:3.6.3-openjdk-11"
+  input[i].Value[0] == "maven:3.8.7-eclipse-temurin-11"
 
   rules := ["untrusted_base_image"]
 }

--- a/.dockerfile-security.rego
+++ b/.dockerfile-security.rego
@@ -86,7 +86,7 @@ deny[msg] {
 
 exception[rules] {
   input[i].Cmd == "from"
-  input[i].Value[0] == "jenkins/jnlp-agent-maven"
+  input[i].Value[0] == "maven"
 
   rules := ["untrusted_base_image"]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,18 +38,20 @@ FROM base_python as base_image
 
 
 # Config vars
-ARG TALISMAN_VERSION=v1.29.4
-ARG TALISMAN_URL=https://github.com/thoughtworks/talisman/releases/download/${TALISMAN_VERSION}/talisman_linux_386
-ARG KUBESCAPE_VERSION=v2.0.180
-ARG KUBESCAPE_URL=https://github.com/kubescape/kubescape/releases/download/${KUBESCAPE_VERSION}/kubescape-ubuntu-latest
 
 RUN apk add --no-cache \
 	openjdk11-jre \
         git \
         gcompat
 
+#
+# Skip talisman and kubescape for now.
+#
+#ARG TALISMAN_VERSION=v1.29.4
+#ARG TALISMAN_URL=https://github.com/thoughtworks/talisman/releases/download/${TALISMAN_VERSION}/talisman_linux_386
+#ARG KUBESCAPE_VERSION=v2.0.180
+#ARG KUBESCAPE_URL=https://github.com/kubescape/kubescape/releases/download/${KUBESCAPE_VERSION}/kubescape-ubuntu-latest
 COPY ./scripts /app/scripts
-
 # Install talisman.
 # RUN . /app/scripts/install_talisman.sh && install_talisman
 # Install kubescape.

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,15 +47,15 @@ RUN apk add --no-cache \
 #
 # Skip talisman and kubescape for now.
 #
-#ARG TALISMAN_VERSION=v1.29.4
-#ARG TALISMAN_URL=https://github.com/thoughtworks/talisman/releases/download/${TALISMAN_VERSION}/talisman_linux_386
-#ARG KUBESCAPE_VERSION=v2.0.180
-#ARG KUBESCAPE_URL=https://github.com/kubescape/kubescape/releases/download/${KUBESCAPE_VERSION}/kubescape-ubuntu-latest
+ARG TALISMAN_VERSION=v1.29.4
+ARG TALISMAN_URL=https://github.com/thoughtworks/talisman/releases/download/${TALISMAN_VERSION}/talisman_linux_386
+ARG KUBESCAPE_VERSION=v2.0.180
+ARG KUBESCAPE_URL=https://github.com/kubescape/kubescape/releases/download/${KUBESCAPE_VERSION}/kubescape-ubuntu-latest
 COPY ./scripts /app/scripts
 # Install talisman.
-# RUN . /app/scripts/install_talisman.sh && install_talisman
+RUN . /app/scripts/install_talisman.sh && install_talisman
 # Install kubescape.
-# RUN . /app/scripts/install_kubescape.sh && install_kubescape
+RUN . /app/scripts/install_kubescape.sh && install_kubescape
 
 # Install trivy.
 COPY --from=trivy /usr/local/bin/trivy /usr/bin/trivy

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ To speed up building, use
 DOCKER_BUILDKIT=1 docker build . -t super-sast
 ```
 
+You can build a ppc64le image on a linux host using
+the  [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static) image.
+Beware that this image executes as root a script
+that registers below kind of /proc/sys/fs/binfmt_misc/qemu-$arch files for all supported processors except the current one in it when running the container (e.g. see `ls -la /proc/sys/fs/binfmt_misc/qemu-*` on your host).
+For further information, see the original repo.
+
+```bash
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+```
+
+**Note**: ppc64le does not support all the tools.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,25 @@ DOCKER_BUILDKIT=1 docker build . -t super-sast
 ```
 
 You can build a ppc64le image on a linux host using
-the  [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static) image.
-Beware that this image executes as root a script
+the  [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static) image that relies on the [Linux Kernel support for miscellaneous binary formats (binfmt_misc)](https://docs.kernel.org/admin-guide/binfmt-misc.html).
+
+Beware that this image executes as `root` a script
 that registers below kind of /proc/sys/fs/binfmt_misc/qemu-$arch files for all supported processors except the current one in it when running the container (e.g. see `ls -la /proc/sys/fs/binfmt_misc/qemu-*` on your host).
-For further information, see the original repo.
+For further information, see the [multiarch/qemu-user-static] repo.
 
 ```bash
 docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker build --platform amd64,ppc64le -t super-sast .
+```
+
+A multiplatform image can be built using the [buildx](https://docs.docker.com/buildx/working-with-buildx/) command.
+
+```bash
+LABEL=$(date +%Y%m%d-%H%M)
+docker buildx build \
+    --platform amd64,ppc64le \
+    -t docker.io/ioggstream/super-sast:$LABEL \
+    --push .
 ```
 
 **Note**: ppc64le does not support all the tools.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Environment variables:
 |Variable|Default|Tool|
 |--------|-------|----|
 |RUN_ALL_TOOLS|true|Run all available tools. Set it to false to selectively enable single tools.|
+|MAVEN_ARGS| |Pass extra arguments to maven3 checks, e.g. `-ntp` to skip logging dependency downloads.|
 
 - Tools variables
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Environment variables:
 |RUN_SEMGREP|true|semgrep|
 |SEMGREP_CONFIG_FILE|auto|semgrep|
 |RUN_SPOTBUGS|true|spotbugs|
+|SPOTBUGS_CONFIG_FILE||spotbugs. Set this to a file in the current repository, e.g. /code/spotbugs-exclude.xml|
 |RUN_OWASP_DEPENDENCY_CHECK|true|owasp_dependency_check|
 |RUN_SPOTLESS_CHECK|true|spotless_check|
 |RUN_SPOTLESS_APPLY|false|spotless_apply|

--- a/config/bandit.yaml
+++ b/config/bandit.yaml
@@ -1,1 +1,11 @@
-{}
+# BEWARE: Bandit does not use any configuration file by default
+#         so you need to specify it using -c.
+# If you have lines in your code triggering vulnerability errors
+# and you are certain that this is acceptable, they can be individually
+# silenced by appending # nosec to the line.
+
+# Bandit does not ignore any directory by default, so you need to
+# specify some directories to ignore.
+exclude_dirs:
+  - .tox
+  - .git

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -1,0 +1,7 @@
+<!--
+    This file is used to exclude SpotBugs warnings from the build.
+    It is used by the spotbugs-maven-plugin.
+    See https://spotbugs.readthedocs.io/en/stable/filter.html for more information.
+-->
+<FindBugsFilter>
+</FindBugsFilter>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
       - M2_HOME=/code
       - HOME=/tmp
       - USER=nobody
+      - MAVEN_OPTS=" -ntp "
       - RUN_OWASP_DEPENDENCY_CHECK=false
       - RUN_SPOTBUGS_CHECK=false
       - RUN_SPOTLESS_CHECK=false

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -63,6 +63,7 @@ TOOLS_MAP = {
     },
     "spotbugs": {
         "cmdline": "mvn com.github.spotbugs:spotbugs-maven-plugin:check",
+        "config_file": "",
     },
     "owasp_dependency_check": {
         "cmdline": "mvn org.owasp:dependency-check-maven:check",

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -46,8 +46,8 @@ TOOLS_MAP = {
         "config_file": "bandit.yaml",
     },
     "safety": {
-        "cmdline": "safety {args} check",
-        "config_file": "safety.yaml",
+        "cmdline": "safety check {args}",
+        "args": "-r requirements.txt",
     },
     "kubescape": {
         "cmdline": "kubescape {args} scan .",

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                     <effort>Max</effort>
                     <threshold>Low</threshold>
                     <failOnError>true</failOnError>
-                    <excludeFilterFile>${spotbugs.excludeFilterFile}</excludeFilterFile>
+                    <excludeFilterFile>${env.SPOTBUGS_CONFIG_FILE}</excludeFilterFile>
                     <plugins>
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>
@@ -39,7 +39,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.4</version>
+                <version>8.0.0</version>
                 <configuration>
                     <cveStartYear>2018</cveStartYear>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                     <effort>Max</effort>
                     <threshold>Low</threshold>
                     <failOnError>true</failOnError>
-                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+                    <excludeFilterFile>${spotbugs.excludeFilterFile}</excludeFilterFile>
                     <plugins>
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>
@@ -31,7 +31,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
                 <executions>
                     <execution>
                         <goals>
-                            <goal>help</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/scripts/install_kubescape.sh
+++ b/scripts/install_kubescape.sh
@@ -1,0 +1,13 @@
+#
+# Functions for installing kubescape.
+#
+install_kubescape(){
+    uname_m=$(uname -m)
+    if [ "${uname_m}" != "x86_64" ] ; then
+        return 0
+    fi
+
+    wget ${KUBESCAPE_URL} -O /usr/bin/kubescape
+    chmod +x /usr/bin/kubescape
+    /usr/bin/kubescape download framework
+}

--- a/scripts/install_kubescape.sh
+++ b/scripts/install_kubescape.sh
@@ -4,6 +4,11 @@
 install_kubescape(){
     uname_m=$(uname -m)
     if [ "${uname_m}" != "x86_64" ] ; then
+        echo "
+        Kubescape is not supported on ${uname_m}
+        exit 1
+        " > /usr/bin/kubescape
+        chmod +x /usr/bin/kubescape
         return 0
     fi
 

--- a/scripts/install_talisman.sh
+++ b/scripts/install_talisman.sh
@@ -1,0 +1,11 @@
+#
+# Functions for installing kubescape.
+#
+install_talisman(){
+    uname_m=$(uname -m)
+    if [ "${uname_m}" != "x86_64" ] ; then
+        return 0
+    fi
+    wget ${TALISMAN_URL} -O /usr/bin/talisman
+    chmod +x /usr/bin/talisman
+}

--- a/scripts/install_talisman.sh
+++ b/scripts/install_talisman.sh
@@ -1,9 +1,14 @@
 #
-# Functions for installing kubescape.
+# Functions for installing talisman.
 #
 install_talisman(){
     uname_m=$(uname -m)
     if [ "${uname_m}" != "x86_64" ] ; then
+        echo "
+        Talisman is not supported on ${uname_m}
+        exit 1
+        " > /usr/bin/talisman
+        chmod +x /usr/bin/talisman
         return 0
     fi
     wget ${TALISMAN_URL} -O /usr/bin/talisman

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -16,6 +16,7 @@ def test_tools(tool, command):
         env={
             "HOME": "/tmp",
             "USER": "nobody",
+            "BANDIT_CONFIG_FILE": "/code/config/bandit.yaml",
             "PATH": ("/usr/local/bin:/usr/local/sbin:" "/usr/sbin:/usr/bin:/sbin:/bin"),
         },
         config_dir=Path("/code/config"),

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ setenv =
 # To show pytest logs in console, use
 #   tox -- --log-cli-level=DEBUG
 commands =
-  pytest --workers auto {posargs}
+  pytest -v --workers auto {posargs}
 
 [testenv:safety]
 envdir = {toxworkdir}/py3


### PR DESCRIPTION
## This PR

- build for ppc64

## Implemented with

- refactored Dockerfile
- use `maven` instead of `jenkins-` image
- skip non-ppc64 tools (talisman, kubescape)
- bump owasp-dependency-check
- add SPOTBUGS_CONFIG_FILE
- download both mvn and plugin dependencies

## Note
- uses cache directory for mvn and pip to speed up build. This will be changed when the build will be consolidated.